### PR TITLE
Y offset fix for resized grids

### DIFF
--- a/addons/MagicaVoxel_Importer_with_Extensions/CulledMeshGenerator.gd
+++ b/addons/MagicaVoxel_Importer_with_Extensions/CulledMeshGenerator.gd
@@ -3,6 +3,7 @@ const vox_to_godot = Basis(Vector3.RIGHT, Vector3.FORWARD, Vector3.UP);
 
 func generate(vox, voxel_data, scale):
 	var generator = VoxelMeshGenerator.new(vox, voxel_data, scale);
+
 	return generator.generate_mesh();
 
 class MeshGenerator:
@@ -56,8 +57,23 @@ class VoxelMeshGenerator:
 		return adj_material.is_glass() && !local_material.is_glass();
 
 	func generate_mesh():
-		var vox_to_godot = Basis(Vector3.RIGHT, Vector3.FORWARD, Vector3.UP);
 
+		# Minimum extends of the volume
+		var mins :Vector3 = Vector3(1000000, 1000000, 1000000)
+		# Maximum extends of the volume
+		var maxs :Vector3 = Vector3(-1000000,-1000000,-1000000)	
+
+		# Find bounds
+		for v in voxel_data:
+			mins.x = min(mins.x, v.x)
+			mins.y = min(mins.y, v.y)
+			mins.z = min(mins.z, v.z)
+			maxs.x = max(maxs.x, v.x)
+			maxs.y = max(maxs.y, v.y)
+			maxs.z = max(maxs.z, v.z)	
+
+		var vox_to_godot = Basis(Vector3.RIGHT, Vector3.FORWARD, Vector3.UP);
+		var yoffset = Vector3(0, -mins.z * scale, 0);
 		var gen = MeshGenerator.new();
 
 		for voxel in voxel_data:
@@ -75,6 +91,6 @@ class VoxelMeshGenerator:
 			gen.ensure_surface_exists(surface_index, color, material);
 
 			for t in voxelSides:
-				gen.add_vertex(surface_index, vox_to_godot.xform((t + voxel) * scale));
+				gen.add_vertex(surface_index, yoffset + vox_to_godot.xform((t + voxel) * scale));
 
 		return gen.combine_surfaces();

--- a/addons/MagicaVoxel_Importer_with_Extensions/CulledMeshGenerator.gd
+++ b/addons/MagicaVoxel_Importer_with_Extensions/CulledMeshGenerator.gd
@@ -1,8 +1,8 @@
 const Faces = preload("./Faces.gd");
 const vox_to_godot = Basis(Vector3.RIGHT, Vector3.FORWARD, Vector3.UP);
 
-func generate(vox, voxel_data, scale):
-	var generator = VoxelMeshGenerator.new(vox, voxel_data, scale);
+func generate(vox, voxel_data, scale, snaptoground):
+	var generator = VoxelMeshGenerator.new(vox, voxel_data, scale, snaptoground);
 
 	return generator.generate_mesh();
 
@@ -39,11 +39,13 @@ class VoxelMeshGenerator:
 	var vox;
 	var voxel_data = {};
 	var scale:float;
+	var snaptoground:bool;
 
-	func _init(vox, voxel_data, scale):
+	func _init(vox, voxel_data, scale, snaptoground):
 		self.vox = vox;
 		self.voxel_data = voxel_data;
 		self.scale = scale;
+		self.snaptoground = snaptoground;
 
 	func get_material(voxel):
 		var surface_index = voxel_data[voxel];
@@ -73,7 +75,8 @@ class VoxelMeshGenerator:
 			maxs.z = max(maxs.z, v.z)	
 
 		var vox_to_godot = Basis(Vector3.RIGHT, Vector3.FORWARD, Vector3.UP);
-		var yoffset = Vector3(0, -mins.z * scale, 0);
+		var yoffset = Vector3(0,0,0);
+		if snaptoground : yoffset = Vector3(0, -mins.z * scale, 0);
 		var gen = MeshGenerator.new();
 
 		for voxel in voxel_data:

--- a/addons/MagicaVoxel_Importer_with_Extensions/GreedyMeshGenerator.gd
+++ b/addons/MagicaVoxel_Importer_with_Extensions/GreedyMeshGenerator.gd
@@ -178,9 +178,10 @@ func generate_geometry_for_face(faces :Dictionary, face :Vector3, o :int, scale 
 	grow[ha] *= height
 	
 	# Generate geometry
+	var yoffset = Vector3(0, -mins.z * scale, 0);
 	st.add_color(faces[face])
 	for vert in face_meshes[o]:
-		st.add_vertex(vox_to_godot.xform(((vert * grow) + face) * scale))
+		st.add_vertex(yoffset + vox_to_godot.xform(((vert * grow) + face) * scale))
 	
 	# Remove these faces from the pool
 	var v :Vector3 = Vector3()

--- a/addons/MagicaVoxel_Importer_with_Extensions/vox-importer.gd
+++ b/addons/MagicaVoxel_Importer_with_Extensions/vox-importer.gd
@@ -44,6 +44,10 @@ func get_import_options(_preset):
 		{
 			'name': 'GreedyMeshGenerator',
 			'default_value': true
+		},
+		{
+			'name': 'SnapToGround',
+			'default_value': false
 		}
 	]
 
@@ -57,6 +61,10 @@ func import(source_path, destination_path, options, _platforms, _gen_files):
 	var greedy = true
 	if options.has("GreedyMeshGenerator"):
 		greedy = bool(options.GreedyMeshGenerator)
+	var snaptoground = false
+	if options.has("SnapToGround"):
+		snaptoground = bool(options.SnapToGround)
+
 
 	var file = File.new()
 	var err = file.open(source_path, File.READ)
@@ -67,7 +75,7 @@ func import(source_path, destination_path, options, _platforms, _gen_files):
 
 	var identifier = PoolByteArray([ file.get_8(), file.get_8(), file.get_8(), file.get_8() ]).get_string_from_ascii()
 	var version = file.get_32()
-	print('Importing: ', source_path, ' (scale: ', scale, ', file version: ', version, ', greedy mesh: ', greedy, ')');
+	print('Importing: ', source_path, ' (scale: ', scale, ', file version: ', version, ', greedy mesh: ', greedy, ', snap to ground: ', snaptoground, ')');
 
 	var vox = VoxData.new();
 	if identifier == 'VOX ':
@@ -79,9 +87,9 @@ func import(source_path, destination_path, options, _platforms, _gen_files):
 	var voxel_data = unify_voxels(vox).data;
 	var mesh
 	if greedy:
-		mesh = GreedyMeshGenerator.new().generate(vox, voxel_data, scale)
+		mesh = GreedyMeshGenerator.new().generate(vox, voxel_data, scale, snaptoground)
 	else:
-		mesh = CulledMeshGenerator.new().generate(vox, voxel_data, scale)
+		mesh = CulledMeshGenerator.new().generate(vox, voxel_data, scale, snaptoground)
 
 	var full_path = "%s.%s" % [ destination_path, get_save_extension() ]
 	return ResourceSaver.save(full_path, mesh)


### PR DESCRIPTION
If you resize the magicavoxel grid from 40 40 40 to say 16 16 16 the resulting vox file will have blocks which are not indexed from 0, when this is imported into godot the model will then be offset from it's origin.

This fix uses the minimum y bound to offset the generated vertices 

The attached model generated with the latest version of MagicaVoxel shows this issue

[example.zip](https://github.com/CloneDeath/MagicaVoxel-Importer-with-Extensions/files/3342050/example.zip)

I've updated my original fix to also support the CulledMeshGenerator
