### PR TITLE
feature - Layer visibility affects what voxels are shown in Godot

### DIFF
--- a/addons/MagicaVoxel_Importer_with_Extensions/VoxFormat/VoxData.gd
+++ b/addons/MagicaVoxel_Importer_with_Extensions/VoxFormat/VoxData.gd
@@ -8,6 +8,8 @@ var colors = null;
 var nodes = {};
 #warning-ignore:unused_class_variable
 var materials = {};
+#warning-ignore:unused_class_variable
+var layers = {};
 
 func get_model():
 	if (!models.has(current_index)):

--- a/addons/MagicaVoxel_Importer_with_Extensions/VoxFormat/VoxLayer.gd
+++ b/addons/MagicaVoxel_Importer_with_Extensions/VoxFormat/VoxLayer.gd
@@ -1,0 +1,6 @@
+var id: int;
+var isVisible: bool;
+
+func _init(id, isVisible):
+	self.id = id;
+	self.isVisible = isVisible;

--- a/addons/MagicaVoxel_Importer_with_Extensions/VoxFormat/VoxNode.gd
+++ b/addons/MagicaVoxel_Importer_with_Extensions/VoxFormat/VoxNode.gd
@@ -1,5 +1,6 @@
 var id: int;
 var attributes = {};
+var layerId = -1;
 var child_nodes = [];
 var models = [];
 var translation = Vector3(0, 0, 0);


### PR DESCRIPTION
This update makes it so that models attached to **hidden** layers are _not_ included in the mesh imported into Godot.
This allows for turning on specific layers for specific situations, such as "goblin" vs "goblin shaman".