### PR TITLE
Layer ordered mesh building

### DIFF
--- a/addons/MagicaVoxel_Importer_with_Extensions/VoxFormat/VoxData.gd
+++ b/addons/MagicaVoxel_Importer_with_Extensions/VoxFormat/VoxData.gd
@@ -8,6 +8,8 @@ var colors = null;
 var nodes = {};
 #warning-ignore:unused_class_variable
 var materials = {};
+#warning-ignore:unused_class_variable
+var layers = {};
 
 func get_model():
 	if (!models.has(current_index)):

--- a/addons/MagicaVoxel_Importer_with_Extensions/VoxFormat/VoxLayer.gd
+++ b/addons/MagicaVoxel_Importer_with_Extensions/VoxFormat/VoxLayer.gd
@@ -1,0 +1,6 @@
+var id: int;
+var isVisible: bool;
+
+func _init(id, isVisible):
+	self.id = id;
+	self.isVisible = isVisible;

--- a/addons/MagicaVoxel_Importer_with_Extensions/VoxFormat/VoxNode.gd
+++ b/addons/MagicaVoxel_Importer_with_Extensions/VoxFormat/VoxNode.gd
@@ -1,5 +1,6 @@
 var id: int;
 var attributes = {};
+var layerId = -1;
 var child_nodes = [];
 var models = [];
 var translation = Vector3(0, 0, 0);

--- a/addons/MagicaVoxel_Importer_with_Extensions/vox-importer.gd
+++ b/addons/MagicaVoxel_Importer_with_Extensions/vox-importer.gd
@@ -281,7 +281,6 @@ class layeredVoxelData:
 		# Merge all layer data in layerId order (highest layer overrides all)
 		for layerId in layerIds:
 			for voxel in layeredData[layerId]:
-				if voxel in data: print(voxel)
 				data[voxel] = layeredData[layerId][voxel];
 		# Return the merged data
 		return data;


### PR DESCRIPTION
When using MagicaVoxel layers, it's sometimes necessary to overlap two models.  For instance, if a low-res figure wears a thin shirt, then it makes more sense to overlap the torso voxels with the shirt voxels, rather have the shirt pad a voxel out from the torso.

This pull request adds user control over which models are "on top" by doing the model merging in order of layer.  Layers further down are merged after earlier layers, so the further down layers (with higher layer ids) take precedence.

---

Note: This pull request sits on top of my previous pull request: "Layer visibility affects what voxels are shown in Godot".  This pull request is actually 2 commits to a single file, "vox-importer.gd".