### PR TITLE
An import option to only use voxels from the first MagicaVoxel keyframe.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,6 @@
+A fork of CloneDeath's Godot plugin [MagicaVoxel importer with extensions](https://github.com/CloneDeath/MagicaVoxel-Importer-with-Extensions).
+
+This fork adds a number of features that are waiting to be pulled into CloneDeath's plugin.  If you wish to use these features _now_ then use _this_ plugin instead.
+- __Hiding layers in MagicaVoxel removes their associated objects from Godot.__ - This allows for toggling optional objects in MagicaVoxel, such as items of clothing.
+- __MagicaVoxel objects are merged in Godot in layer order.__ - Later layers are merged "on top" of earlier layers when imported into Godot.  This allows the user to control which objects show "on top".  It is useful for adding tight features where an extra voxel is inappropriate, such as for facial expressions, or tight clothing.
+- __An option to only use voxels from the first MagicaVoxel keyframe.__ - MagicaVoxel now allows creating multiple keyframes of voxels.  If each keyframe represents a separate pose then it can look strange when they are all imported into Godot on top of each other.  This option fixes that.

--- a/addons/MagicaVoxel_Importer_with_Extensions/VoxFormat/VoxData.gd
+++ b/addons/MagicaVoxel_Importer_with_Extensions/VoxFormat/VoxData.gd
@@ -8,6 +8,8 @@ var colors = null;
 var nodes = {};
 #warning-ignore:unused_class_variable
 var materials = {};
+#warning-ignore:unused_class_variable
+var layers = {};
 
 func get_model():
 	if (!models.has(current_index)):

--- a/addons/MagicaVoxel_Importer_with_Extensions/VoxFormat/VoxLayer.gd
+++ b/addons/MagicaVoxel_Importer_with_Extensions/VoxFormat/VoxLayer.gd
@@ -1,0 +1,6 @@
+var id: int;
+var isVisible: bool;
+
+func _init(id, isVisible):
+	self.id = id;
+	self.isVisible = isVisible;

--- a/addons/MagicaVoxel_Importer_with_Extensions/VoxFormat/VoxNode.gd
+++ b/addons/MagicaVoxel_Importer_with_Extensions/VoxFormat/VoxNode.gd
@@ -1,5 +1,6 @@
 var id: int;
 var attributes = {};
+var layerId = -1;
 var child_nodes = [];
 var models = [];
 var translation = Vector3(0, 0, 0);

--- a/addons/MagicaVoxel_Importer_with_Extensions/vox-importer.gd
+++ b/addons/MagicaVoxel_Importer_with_Extensions/vox-importer.gd
@@ -281,7 +281,6 @@ class layeredVoxelData:
 		# Merge all layer data in layerId order (highest layer overrides all)
 		for layerId in layerIds:
 			for voxel in layeredData[layerId]:
-				if voxel in data: print(voxel)
 				data[voxel] = layeredData[layerId][voxel];
 		# Return the merged data
 		return data;


### PR DESCRIPTION
MagicaVoxel now allows creating multiple keyframes of voxels. If each keyframe represents a separate pose then it can look strange when they are all imported into Godot on top of each other. This import option fixes that.

---

Note: This pull requests sits on top of my previous two pull requests.  It's only a single commit.
